### PR TITLE
Only start discordbot thread when running server

### DIFF
--- a/apps/csua_backend/wsgi.py
+++ b/apps/csua_backend/wsgi.py
@@ -31,3 +31,10 @@ application = get_wsgi_application()
 # Apply WSGI middleware here.
 # from helloworld.wsgi import HelloWorldApplication
 # application = HelloWorldApplication(application)
+
+# We start discordbot thread here so that it doesn't interfere with other django
+# commands such as test and migrate
+from apps.discordbot.bot import csua_bot
+
+if csua_bot:
+    csua_bot.thread.start()

--- a/apps/discordbot/bot.py
+++ b/apps/discordbot/bot.py
@@ -146,13 +146,14 @@ class CSUABot:
     `asyncio.run_coroutine_threadsafe` because the client is running inside an
     event loop in a separate thread. Event loops are one per-thread, and Django
     can't handle async code, so a separate thread is used instead.
+
+    CSUABot.thread is started in apps/csua_backend/wsgi.py, so that it doesn't
+    run during other django commands such as migrate, test etc.
     """
 
     def __init__(self):
         self.loop = asyncio.new_event_loop()
         self.thread = threading.Thread(target=self._start, daemon=True)
-        self.running = True
-        self.thread.start()
 
     def _start(self):
         asyncio.set_event_loop(self.loop)


### PR DESCRIPTION
This way the discord bot doesn't start up while doing unrelated things like test/migrate