### PR TITLE
Fix Tutoring Page

### DIFF
--- a/templates/tutoring.html
+++ b/templates/tutoring.html
@@ -2,20 +2,22 @@
 {% block title %}Tutoring{% endblock %}
 {% block pagetitle %}Tutoring{% endblock %}
 {% block page_content %}
+
 <p>
 Need help with your classes?
-Officers of the CSUA provide free tutoring services in 311 Soda.
+Officers of the CSUA host office hours and tutoring services on
+<a href="https://csua.org/discord">
+Discord!
+</a>
 </p>
 <br>
 
 <p>
-If you cannot make it to any tutoring appointments, you are always welcome to
-come to our office hours on Discord! (https://csua.org/discord).
-Most officers are willing to help you with your classes, just come in and say hi!
+Most officers are willing to help you out with your classes, root staff work, or just come in and say hi!
 </p>
 <br>
 
-<! --
+<!--
 <p>
 <a class="button is-link" href="https://calendar.google.com/calendar/selfsched?sstoken=UUJwQ00ycnRfbFdhfGRlZmF1bHR8OTljZWU2NGY2Yzg5MWZiZTkwYjZmOTliOWIyN2RkNDY">
         Click here to book a tutoring / advising appointment


### PR DESCRIPTION
The tutoring page is fixed for an online format, with a link to the discord for office hours and the button used to get to the tutoring services that we haven't been happening this semester commented out. These should be changed back when we get back to an in person format. I actually tested it this time so the changes should work.